### PR TITLE
Fixed the sql query for getting the account_cn

### DIFF
--- a/src/main/java/com/miniconomy/commercial_bank_service/financial_management/service/AccountService.java
+++ b/src/main/java/com/miniconomy/commercial_bank_service/financial_management/service/AccountService.java
@@ -31,7 +31,7 @@ public class AccountService
 
   public String findAccountNameByCn(String cn)
   {
-    String sql = "SELECT account_name FROM account WHERE common_name = :cn";
+    String sql = "SELECT account_name FROM account WHERE account_cn = :cn";
     SqlParameterSource parameters = new MapSqlParameterSource().addValue("cn", cn);
     return jdbcTemplate.queryForObject(sql, parameters, String.class);
   }


### PR DESCRIPTION
# Description

Fixed the sql query for getting the account_cn. Changed 'common_name' to 'account_cn'

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update